### PR TITLE
Version needed to be a string

### DIFF
--- a/poc_snapshot.py
+++ b/poc_snapshot.py
@@ -1,18 +1,19 @@
 #! /usr/bin/env python3
-pocUtilsVersion = 2.2
+pocUtilsVersion = '2.2'
 
 #--python imports
 import argparse
-try: import configparser
-except: import ConfigParser as configparser
+import csv
+import json
 import os
-import sys
+import random
 import signal
+import sys
 import time
 from datetime import datetime, timedelta
-import json
-import csv
-import random
+
+try: import configparser
+except: import ConfigParser as configparser
 
 #--senzing python classes
 try: from G2Database import G2Database


### PR DESCRIPTION
Version needed to be a string

# Pull request questions

## Which issue does this address

Issue number: #nnn

## Why was change needed

poc_viewer.py was trying to define 

## What does change improve pocUtilsVersion with 3 parts: pocUtilsVersion = 2.2.1 which is invalid and needed to be a string. Change poc_snapshot to follow so it to can have 3 parts if/when required. 

???
